### PR TITLE
Add repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.11",
   "description": "An schedule module for WFM",
   "main": "lib/angular/schedule-ng.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/feedhenry-raincatcher/raincatcher-schedule.git"
+  },
   "scripts": {
     "build": "wfm-template-build -m 'wfm.schedule.directives'",
     "watch": "wfm-template-build -w -m 'wfm.schedule.directives'",


### PR DESCRIPTION
Prevents warning during `npm install`.