### PR TITLE
Switched comparison of workorders to be falsy 

### DIFF
--- a/lib/angular/directive.js
+++ b/lib/angular/directive.js
@@ -64,8 +64,10 @@ ngModule.directive('schedule', function($templateCache, $compile, $timeout, medi
   }
 
   function renderUnscheduledWorkorderList(scope, ctrl, element) {
+
+    //A workorder is unscheduled if it has no assigned user or it has no start time.
     var unscheduled = scope.workorders.filter(function(workorder) {
-      return workorder.assignee === null || workorder.startTimestamp === null;
+      return !workorder.assignee || !workorder.startTimestamp;
     });
     var unscheduledWorkorderList = element.querySelector('.wfm-scheduler-unscheduled');
     unscheduled.forEach(function(workorder) {


### PR DESCRIPTION
# Motivation

When filtering for un-assigned work orders, the comparison does a strict === with `null`.

It is not guaranteed that the comparison fields will be present and will therefore be `undefined`. This will fail the comparison.

Therefore, switching to a falsy check will catch that case.