### PR TITLE
remove travis nsp checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,12 @@ node_js:
 sudo: false
 services:
   - docker
-script:
-  - npm test
-  - nsp check; exit 0
-  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 before_install:
   - npm install -g npm@2.13.5
-  - npm install -g nsp
 install: npm install
+script:
+  - npm test
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false
   slack:


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.